### PR TITLE
Revert "add GA4 tags to every page via the default layout"

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,20 +51,6 @@
     />
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css" />
   </head>
-  <!-- Google tag (gtag.js) -->
-  <script
-    async
-    src="https://www.googletagmanager.com/gtag/js?id=G-D21LJ0PVM3"
-  ></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-
-    gtag("config", "G-D21LJ0PVM3");
-  </script>
   <body>
     <a class="usa-skipnav" href="#main-content">Skip to main content</a>
     {% include banner.html %} {% include header.html %} {{ content }} {% include


### PR DESCRIPTION
Need to update the CSP before bringing in Google tag manager