### PR TITLE
Adjust size of feedback widget

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,8 +2,13 @@
   <div class="grid-container usa-footer__return-to-top">
     <a href="#">Return to top</a>
   </div>
-  
-  <feedback-widget contact-link="mailto:team@innovation.nj.gov"></feedback-widget>
+  <div style="background-color: #fbfcfd">
+    <div class="grid-container">
+      <feedback-widget
+        contact-link="mailto:team@innovation.nj.gov"
+      ></feedback-widget>
+    </div>
+  </div>
   <div class="usa-footer__secondary-section">
     <div class="grid-container">
       <div class="grid-row grid-gap">


### PR DESCRIPTION
Puts the feedback widget in a container to keep it from breaking the width of the page container

<details>
 <summary>Before</summary>
  <img width="1398" alt="image" src="https://github.com/user-attachments/assets/33b80a7a-10f3-4725-9e47-20a7411afc4a">
</details>

<details>
 <summary>After</summary>
  <img width="1011" alt="image" src="https://github.com/user-attachments/assets/fb8fce39-5018-445f-b7b5-37e135641813">20a7411afc4a">
</details>

Note: the feedback element has padding built in, so it's indented a bit — we could remove this is we want flush alignment.




