### PR TITLE
Override uswds paragraph max width

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -35,6 +35,11 @@ a.text-primary-darker {
   text-decoration: underline;
 }
 
+/* text */
+.usa-prose>p {
+  max-width: fit-content;
+}
+
 /* SVG */
 path.white-fill {
   fill: white;


### PR DESCRIPTION
submitted by Jasmine: 

Because of the `.prose-usa>p` selector that has a max-width of 68ex from [USWDS](https://designsystem.digital.gov/components/prose/), this causes some of the sections to look like the paragraph width is too short. I believe this specifically impacts `<p>` without other USWDS classes. For instance:

https://github.com/user-attachments/assets/2a472cda-77fa-4fa6-9703-b6d0d9017de9

I will bring this up with the NJWDS group to consider overriding this in the NJWDS (as I know it has also had impact in other projects), but in the short term I recommend overriding this to not have this value (alternatively, thinking through the overall design of the pages and what the max paragraph width should actually look like).
 
Closes https://github.com/newjersey/innovation.nj.gov-pm/issues/12