### PR TITLE
Temporarily force bundler 2.5.23

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
+gem 'bundler', '~> 2.5', '>= 2.5.23'
 gem "jekyll", "~> 4.3.3"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 # gem "minima", "~> 2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,25 +12,9 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.17.0)
-    ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x64-mingw-ucrt)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
-    google-protobuf (4.27.2)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.27.2-arm64-darwin)
-      bigdecimal
-      rake (>= 13)
     google-protobuf (4.27.2-x64-mingw-ucrt)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.27.2-x86_64-darwin)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.27.2-x86_64-linux)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -67,17 +51,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    mini_portile2 (2.8.7)
-    nokogiri (1.16.6)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.16.6-arm64-darwin)
-      racc (~> 1.4)
     nokogiri (1.16.6-x64-mingw-ucrt)
-      racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -91,16 +65,7 @@ GEM
       strscan
     rouge (4.3.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.77.8)
-      google-protobuf (~> 4.26)
-      rake (>= 13)
-    sass-embedded (1.77.8-arm64-darwin)
-      google-protobuf (~> 4.26)
     sass-embedded (1.77.8-x64-mingw-ucrt)
-      google-protobuf (~> 4.26)
-    sass-embedded (1.77.8-x86_64-darwin)
-      google-protobuf (~> 4.26)
-    sass-embedded (1.77.8-x86_64-linux-gnu)
       google-protobuf (~> 4.26)
     strscan (3.1.0)
     terminal-table (3.0.2)
@@ -115,14 +80,11 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
-  arm64-darwin-23
-  universal-darwin-22
   x64-mingw-ucrt
-  x64-unknown
-  x86_64-linux
 
 DEPENDENCIES
   base64 (~> 0.2.0)
+  bundler (~> 2.5, >= 2.5.23)
   csv (~> 3.3)
   jekyll (~> 4.3.3)
   jekyll-sitemap
@@ -133,4 +95,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.5.16
+   2.5.23

--- a/amplify.yml
+++ b/amplify.yml
@@ -3,9 +3,9 @@ frontend:
   phases:
     preBuild:
       commands:
-        - gem install bundler
-        - bundle config set path 'vendor/bundle'
-        - bundle install
+        - gem install bundler -v 2.5.23
+        - bundle _2.5.23_ config set path 'vendor/bundle'
+        - bundle _2.5.23_ install
     build:
       commands:
         - npm run build

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "scripts": {
     "import-nj-node": "chmod u+x importNJNodePackages.sh && bash importNJNodePackages.sh",
-    "build": "npm run import-nj-node && bundle exec rake generate_jobs && bundle exec jekyll build",
-    "serve": "bundle exec jekyll serve"
+    "build": "npm run import-nj-node && bundle _2.5.23_ exec rake generate_jobs && bundle _2.5.23_ exec jekyll build",
+    "serve": "bundle _2.5.23_ exec jekyll serve"
   }
 }


### PR DESCRIPTION
Until [this issue](https://github.com/rubygems/rubygems/issues/8339) with bundler 2.6+ is resolved, we will force an older version of bundler that did not have this issue so our site can continue to build successfully