### PR TITLE
fix(decap): Allow creation of blog posts via decap

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -7,11 +7,13 @@ backend:
   publish_mode: editorial_workflow
   squash_merges: true
 media_folder: "assets/images"
+
 collections:
   - name: "blog"
-    label: "Blog"
+    label: "Blog Posts"
     folder: "content/_blog/"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    create: true
     fields:
       # Read-only fields
       - name: layout

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -6,7 +6,8 @@ backend:
   auth_endpoint: auth
   publish_mode: editorial_workflow
   squash_merges: true
-media_folder: "assets/images"
+media_folder: assets/images
+public_folder: /assets/images
 
 collections:
   - name: "blog"
@@ -14,6 +15,7 @@ collections:
     folder: "content/_blog/"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     create: true
+    summary: "{{title}} - {{date | date('MM/DD/YYYY')}} – {{body | truncate(50, '***')}}"
     fields:
       # Read-only fields
       - name: layout
@@ -29,6 +31,11 @@ collections:
         label: Author
         widget: string
         required: true
+      - name: date
+        label: Publish Date
+        widget: datetime
+        default: { { now } }
+        required: true
       # Optional fields
       - name: excerpt
         label: Excerpt
@@ -43,12 +50,12 @@ collections:
         required: false
       - name: promoted
         label: Promoted Order
-        hint: You can have up to 3 promoted posts in total. \"0\" values are ignored
+        hint: There is only 1 promoted blog post at a time. \"0\" values (the default) are unpromoted.
         widget: number
         value_type: "int"
         default: 0
         min: 0
-        max: 3
+        max: 1
         required: true
       - name: figure
         label: Inline Image
@@ -75,3 +82,59 @@ collections:
         label: Body
         required: true
         widget: markdown
+  - name: "news"
+    label: "News Posts"
+    folder: "content/_news/"
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    summary: "{{title}} - {{date | date('MM/DD/YYYY')}} – {{body | truncate(50, '***')}}"
+    create: true
+    fields:
+      # Required fields
+      - name: title
+        label: Title
+        widget: string
+        required: true
+      - name: date
+        label: Publish Date
+        hint: This should be the date the referenced article was published
+        widget: datetime
+        default: { { now } }
+        required: true
+      - name: source
+        label: Source
+        hint: e.g. the name of the site/org/dept that published the article
+        widget: string
+        required: true
+      - name: image
+        label: Icon Image
+        widget: image
+        media_folder: "assets/images"
+        allow_multiple: false
+        choose_url: false
+        required: true
+      - name: promoted
+        label: Promoted Order
+        hint: You can have up to 3 promoted posts in total. \"0\" values (the default) are unpromoted.
+        widget: number
+        value_type: "int"
+        default: 0
+        min: 0
+        max: 3
+        required: true
+      - name: body
+        label: Description
+        hint: A brief description of the article's content.
+        required: true
+        widget: markdown
+      - name: cta
+        label: Article Link
+        widget: object
+        required: true
+        fields:
+          - name: link
+            label: Url
+            widget: string
+          - name: text
+            label: Button Text
+            default: Continue Reading
+            widget: string

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -15,7 +15,7 @@ collections:
     folder: "content/_blog/"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     create: true
-    summary: "{{title}} - {{date | date('MM/DD/YYYY')}} – {{body | truncate(50, '***')}}"
+    summary: '{{title}} ({{date | date("MM/DD/YYYY")}}): "{{body | truncate(80, "...")}}"'
     fields:
       # Read-only fields
       - name: layout
@@ -34,6 +34,7 @@ collections:
       - name: date
         label: Publish Date
         widget: datetime
+        date_format: true
         default: { { now } }
         required: true
       # Optional fields
@@ -86,7 +87,7 @@ collections:
     label: "News Posts"
     folder: "content/_news/"
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
-    summary: "{{title}} - {{date | date('MM/DD/YYYY')}} – {{body | truncate(50, '***')}}"
+    summary: '{{title}} // ({{date | date("MM/DD/YYYY")}}) // "{{body | truncate(80, "...")}}"'
     create: true
     fields:
       # Required fields
@@ -98,6 +99,7 @@ collections:
         label: Publish Date
         hint: This should be the date the referenced article was published
         widget: datetime
+        date_format: true
         default: { { now } }
         required: true
       - name: source

--- a/content/_blog/2022-11-14-public-engagement-survey.md
+++ b/content/_blog/2022-11-14-public-engagement-survey.md
@@ -1,6 +1,7 @@
 ---
 layout: blog
 title: How we used a simple survey tool to elevate public engagement
+date: 2022-11-14
 slug: public-engagement-survey
 author: Edward Paulino
 image: /assets/images/nj-logo.svg

--- a/content/_blog/2023-03-09-climate-future-public-outreach.md
+++ b/content/_blog/2023-03-09-climate-future-public-outreach.md
@@ -1,6 +1,7 @@
 ---
 layout: blog
 title: How New Jersey Tapped the Public to Help Shape its Climate Future
+date: 2023-03-09
 author: Edward Paulino
 image: /assets/images/nj-logo.svg
 promoted: 0

--- a/content/_blog/2025-05-01-nj-gov-disabilities-hub.md
+++ b/content/_blog/2025-05-01-nj-gov-disabilities-hub.md
@@ -1,6 +1,7 @@
 ---
 layout: blog
 title: Making it easier for the disability community to find services through NJ.gov/disabilities
+date: 2025-05-01
 author: Crystal Peñalosa, Digital Product Lead
 promoted: 0
 excerpt: The Office of Innovation worked across agencies and the disability community to create a popular hub of resources for New Jerseyans with disabilities, their families, and caregivers.

--- a/content/_blog/2025-05-08-directfile-recap.md
+++ b/content/_blog/2025-05-08-directfile-recap.md
@@ -1,6 +1,7 @@
 ---
 layout: blog
 title: Taxpayers Save Time, Money in First Year of Direct File in New Jersey
+date: 2025-05-08
 author: Dave Cole, Chief Innovation Officer
 promoted: 0
 excerpt: Many New Jerseyans liked using the new, free, easy way to file their taxes directly with government. The 8,500 participants this year saved roughly $1.3 million in filing fees and received over $3 million in refunds.

--- a/content/_blog/2025-05-15-fundmyfuture.md
+++ b/content/_blog/2025-05-15-fundmyfuture.md
@@ -1,6 +1,7 @@
 ---
 layout: blog
 title: Why Emotional Connection is Key to Program Uptake
+date: 2025-05-15
 author: Katie Fiore, Director, Communication + Engagement Lab
 promoted: 0
 excerpt: How the Office of Innovation’s Communications + Engagement Lab transformed the communication of an upskilling program into a promise for a better future.

--- a/content/_blog/2025-06-05-callcentermodernization.md
+++ b/content/_blog/2025-06-05-callcentermodernization.md
@@ -1,6 +1,7 @@
 ---
 layout: blog
 title: Making Government Call Centers More Human-Centered and More Efficient
+date: 2025-06-05
 author: Joe DeLaTorre, Product Manager, and Jessica Lax, Senior Advisor for Responsible AI
 promoted: 0
 excerpt: New Jersey used best practices in menu design to modernize 12 call centers... and continues to enhance the caller experience by leveraging AI.

--- a/content/_blog/2025-06-26-transportation-needs-index.md
+++ b/content/_blog/2025-06-26-transportation-needs-index.md
@@ -1,6 +1,7 @@
 ---
 layout: blog
 title: Unlocking New Jersey's Full Transit Potential
+date: 2025-06-26
 author: Edward Paulino, Innovation Fellow
 promoted: 0
 excerpt: A new interactive map pulls from several New Jersey data sets to show where transportation needs are high but access to transportation is low.

--- a/content/_blog/2025-07-17-aiassistantanniversary.md
+++ b/content/_blog/2025-07-17-aiassistantanniversary.md
@@ -1,6 +1,7 @@
 ---
 layout: blog
 title: On First Anniversary, GenAI Tool is Helping Thousands of Public Sector Professionals
+date: 2025-07-17
 author: Ruthie Nachmany, Product Lead, Platform Team
 promoted: 0
 excerpt: On its first anniversary, the New Jersey AI Assistant is helping thousands of public-sector professionals use GenAI to save time and money while improving services for residents.

--- a/content/_blog/2025-08-08-translation.md
+++ b/content/_blog/2025-08-08-translation.md
@@ -1,6 +1,7 @@
 ---
 layout: blog
 title: Amplifying Human-Centered Language Access in New Jersey
+date: 2025-08-08
 author: Barbara Niveyro, Bilingual Content Design Lead
 promoted: 1
 excerpt: The Office of Innovation is leading with a human-centered approach to ensure meaningful translations, even as it uses AI to scale up.

--- a/content/_news/2019-04-29-njdep.md
+++ b/content/_news/2019-04-29-njdep.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/dep.jpg
 title: "PPRESS RELEASE: Online Land-use Permit System Will Improve DEP Efficiency and Public Transparency"
-date: April 29, 2019
+date: 2019-04-29
 source: Department of Environmental Preservation
 cta:
   text: Continue Reading

--- a/content/_news/2019-05-03-gov.md
+++ b/content/_news/2019-05-03-gov.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/scooters.jpg
 title: "PRESS RELEASE: Governor Murphy Signs Legislation Permitting Operation of Low Speed E-Bikes and Motorized Scooters"
-date: May 3, 2019
+date: 2019-05-03
 source: Office of the Governor
 cta:
   text: Continue Reading

--- a/content/_news/2019-06-17-gov.md
+++ b/content/_news/2019-06-17-gov.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/logo-insa.png
 title: "PRESS RELEASE: Governor Murphy Launches Innovation Skills Accelerator Training Program to Promote Innovation in Government"
-date: June 17, 2019
+date: 2019-06-17
 source: Office of the Governor
 cta:
   text: Continue Reading

--- a/content/_news/2019-07-16-news-india-times.md
+++ b/content/_news/2019-07-16-news-india-times.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/india-visit.jpg
 title: "COVERAGE: Gov. Phil Murphy announces economic mission trip to India"
-date: July 16, 2019
+date: 2019-07-16
 source: News India Times
 cta:
   text: Continue Reading

--- a/content/_news/2019-07-16-njeda.md
+++ b/content/_news/2019-07-16-njeda.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/fl-murphy.jpg
 title: "PRESS RELEASE: First Lady Tammy Murphy and NJEDA Announce Partnership with Golden Seeds to Increase Funding for Women-Led Startups"
-date: July 16, 2019
+date: 2019-07-16
 source: Office of the Governor
 cta:
   text: Continue Reading

--- a/content/_news/2019-08-01-njtv.md
+++ b/content/_news/2019-08-01-njtv.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/bsn-njtv.png
 title: "COVERAGE: New Jersey State Chief Innovation Officer Beth Noveck Appears on NJTV State of Affairs with Steve Adubato"
-date: August 1, 2019
+date: 2019-08-01
 source: NJTV
 cta:
   text: Watch Now

--- a/content/_news/2019-10-01-gov.md
+++ b/content/_news/2019-10-01-gov.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/bfs-logo.001.png
 title: "PRESS RELEASE: Governor Murphy Marks One-Year Anniversary of Economic Plan"
-date: October 1, 2019
+date: 2019-10-01
 source: Office of the Governor
 cta:
   text: Continue Reading

--- a/content/_news/2019-10-29-njeda.md
+++ b/content/_news/2019-10-29-njeda.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/njeda-econ-2.png
 title: "COVERAGE: NJEDA Podcast, ECONversations, features Chief Innovation Officer Beth Noveck"
-date: October 29, 2019
+date: 2019-10-29
 source: NJEDA
 cta:
   text: Listen Here

--- a/content/_news/2019-12-19-gov.md
+++ b/content/_news/2019-12-19-gov.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/enjine-awards.jpg
 title: "PRESS RELEASE: Governor Murphy, Chief Innovation Officer Beth Simone Noveck Announce Winners of Innovation ENJINE Challenge"
-date: December 19, 2019
+date: 2019-12-19
 source: Office of the Governor
 cta:
   text: Continue Reading

--- a/content/_news/2020-01-15-gov.md
+++ b/content/_news/2020-01-15-gov.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/jobsnj-sq.png
 title: "PRESS RELEASE: Governor Murphy Announces “Jobs NJ: Developing Talent to Grow Business in the Garden State”"
-date: January 15, 2020
+date: 2020-01-15
 source: Office of the Governor
 cta:
   text: Continue Reading

--- a/content/_news/2020-01-24-commons.md
+++ b/content/_news/2020-01-24-commons.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/thecommons.jpg
 title: "INTERVIEW: New America Publication, The Commons, Features Interview with Chief Innovation Officer & Digital Director on Starting an Innovation Team"
-date: January 24, 2020
+date: 2020-01-24
 source: The Commons
 cta:
   text: Continue Reading

--- a/content/_news/2020-03-21-gov.md
+++ b/content/_news/2020-03-21-gov.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/nj-covid-info-hub.png
 title: "PRESS RELEASE: Governor Murphy Announces Launch of New Jersey COVID-19 Website"
-date: March 21, 2020
+date: 2020-03-21
 source: Office of the Governor
 cta:
   text: Continue Reading

--- a/content/_news/2020-03-23-techcrunch.md
+++ b/content/_news/2020-03-23-techcrunch.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/techcrunch.png
 title: "COVERAGE: New Jersey launches online portal to give residents accurate answers about COVID-19"
-date: March 23, 2020
+date: 2020-03-23
 source: TechCrunch
 cta:
   text: Continue Reading

--- a/content/_news/2020-03-24-gov.md
+++ b/content/_news/2020-03-24-gov.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/jobs-covid19.png
 title: "PRESS RELEASE: New Jersey Launches Job Portal to Connect Out-of-Work Residents to Opportunities in Critical Industries"
-date: March 24, 2020
+date: 2020-03-24
 source: Office of the Governor
 cta:
   text: Continue Reading

--- a/content/_news/2020-03-24-state-scoop.md
+++ b/content/_news/2020-03-24-state-scoop.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/statescoop.png
 title: "COVERAGE: New Jersey's new coronavirus website lets users ask questions"
-date: March 24, 2020
+date: 2020-03-24
 source: State Scoop
 cta:
   text: Continue Reading

--- a/content/_news/2020-03-26-tap.md
+++ b/content/_news/2020-03-26-tap.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/jobs-portal.jpg
 title: "COVERAGE: Resources in Place for NJ Workers Dealt Blow By COVID-19 Job Losses"
-date: March 26, 2020
+date: 2020-03-26
 source: TAPinto.net
 cta:
   text: Continue Reading

--- a/content/_news/2020-03-31-njtv.md
+++ b/content/_news/2020-03-31-njtv.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/job-covid-njtv.png
 title: "COVERAGE: NJ’s newly-launched jobs portal attracts thousands of job hunters"
-date: March 31, 2020
+date: 2020-03-31
 source: NJTV News
 cta:
   text: Continue Reading

--- a/content/_news/2020-04-20-njtv.md
+++ b/content/_news/2020-04-20-njtv.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/njtv-logo.jpg
 title: "INTERVIEW: Chief Innovation Officer discusses ‘peak’ and predictive modeling"
-date: April 20, 2020
+date: 2020-04-20
 source: NJTV News
 cta:
   text: Continue Reading

--- a/content/_news/2020-05-12-roi-nj.md
+++ b/content/_news/2020-05-12-roi-nj.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/chat-bot-image.jpg
 title: "COVERAGE: Labor Department launches online chatbot for most asked unemployment questions"
-date: May 12, 2020
+date: 2020-05-12
 source: ROI-NJ
 cta:
   text: Continue Reading

--- a/content/_news/2020-06-29-innovation.md
+++ b/content/_news/2020-06-29-innovation.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/digital-service-article.jpeg
 title: "POST: Four Ways State Government Digital Service Teams Can Support the COVID-19 Response"
-date: June 29, 2020
+date: 2020-06-29
 source: New Jersey Office of Innovation Medium
 cta:
   text: Continue Reading

--- a/content/_news/2020-07-16-state-scoop.md
+++ b/content/_news/2020-07-16-state-scoop.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/statescoop.png
 title: "COVERAGE: New Jersey's innovation office shares digital service from the pandemic"
-date: July 16, 2020
+date: 2020-07-16
 source: State Scoop
 cta:
   text: Continue Reading

--- a/content/_news/2020-09-12-innovation.md
+++ b/content/_news/2020-09-12-innovation.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/bfs-article.jpeg
 title: "POST: Open Sourcing a New Approach to Serving Businesses in New Jersey"
-date: September 12, 2020
+date: 2020-09-12
 source: New Jersey Office of Innovation Medium
 cta:
   text: Continue Reading

--- a/content/_news/2020-09-17-rockefeller.md
+++ b/content/_news/2020-09-17-rockefeller.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/njcn_rockefeller.jpeg
 title: "FEATURE: An Equity-Based Job Search Site with Heart Creates a Quiet Revolution in Public Problem Solving"
-date: September 17, 2020
+date: 2020-09-17
 source: The Rockefeller Foundation
 cta:
   text: Continue Reading

--- a/content/_news/2020-09-25-innovation-2.md
+++ b/content/_news/2020-09-25-innovation-2.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/fow_image4.png
 title: "POST: What We Learned About the Future of Work from 4,000 Workers in New Jersey"
-date: September 25, 2020
+date: 2020-09-25
 source: New Jersey Office of Innovation Medium
 cta:
   text: Continue Reading

--- a/content/_news/2020-09-25-innovation.md
+++ b/content/_news/2020-09-25-innovation.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/fow_image2.jpeg
 title: "POST: How New Jersey Asked Workers About the Future of Work: The Importance of Partnership"
-date: September 25, 2020
+date: 2020-09-25
 source: New Jersey Office of Innovation Medium
 cta:
   text: Continue Reading

--- a/content/_news/2020-09-25-nj-spotlight.md
+++ b/content/_news/2020-09-25-nj-spotlight.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/fow_njspotlight.jpg
 title: "COVERAGE: Workers fear losing full-time jobs, no training, corporate surveillance"
-date: September 25, 2020
+date: 2020-09-25
 source: NJ Spotlight
 cta:
   text: Continue Reading

--- a/content/_news/2020-10-16-nj-tech.md
+++ b/content/_news/2020-10-16-nj-tech.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJTechWeekly.jpg
 title: "COVERAGE: Panel Sees Opportunity for New Jersey to Capitalize on COVID-induced Workplace Trends"
-date: October 16, 2020
+date: 2020-10-16
 source: NJ Tech Weekly
 cta:
   text: Continue Reading

--- a/content/_news/2020-11-19-choose-nj.md
+++ b/content/_news/2020-11-19-choose-nj.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/The-Hub-New-Brunswick.jpg
 title: "RELEASE: Governor Phil Murphy Announces First Tenants of The Hub in New Brunswick"
-date: November 19, 2020
+date: 2020-11-19
 source: Choose New Jersey
 cta:
   text: Continue Reading

--- a/content/_news/2020-12-02-bloomberg.md
+++ b/content/_news/2020-12-02-bloomberg.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/BSN-bloomberg.jpeg
 title: "COVERAGE: 6 Lessons Cities Can Learn from New Jersey’s Cutting-Edge Innovation Team"
-date: December 2, 2020
+date: 2020-12-02
 source: Bloomberg Cities
 cta:
   text: Continue Reading

--- a/content/_news/2020-12-09-fox29.md
+++ b/content/_news/2020-12-09-fox29.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/fox29.png
 title: "COVERAGE: New Jersey forecasts the next several weeks of the coronavirus pandemic"
-date: December 9, 2020
+date: 2020-12-09
 source: Fox29
 cta:
   text: Continue Reading

--- a/content/_news/2021-02-18-innovation.md
+++ b/content/_news/2021-02-18-innovation.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/covid19jobs.jpeg
 title: "CASE STUDY: How New Jersey connected workforce supply and demand during the pandemic"
-date: February 18, 2021
+date: 2021-02-18
 source: New Jersey Office of Innovation Medium
 cta:
   text: Continue Reading

--- a/content/_news/2021-02-18-statescoop.md
+++ b/content/_news/2021-02-18-statescoop.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/statescoop.png
 title: "REPORT: How New Jersey tracked COVID-19 when no data was available"
-date: February 18, 2021
+date: 2021-02-18
 source: StateScoop
 cta:
   text: Continue Reading

--- a/content/_news/2021-03-31-nj-com.md
+++ b/content/_news/2021-03-31-nj-com.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/njcomlogo.png
 title: "COVERAGE: N.J. launches new tool to help you find COVID vaccination appointments"
-date: March 31, 2021
+date: 2021-03-31
 source: NJ.COM
 cta:
   text: Continue Reading

--- a/content/_news/2021-04-06-cape-may-county-herald.md
+++ b/content/_news/2021-04-06-cape-may-county-herald.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/use-of-force-dashboard.jpeg
 title: "COVERAGE: 'Beta Version' of State's Use of Force Dashboard Launched"
-date: April 6, 2021
+date: 2021-04-06
 source: Cape May County Herald
 cta:
   text: Continue Reading

--- a/content/_news/2021-04-15-statescoop.md
+++ b/content/_news/2021-04-15-statescoop.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/statescoop.png
 title: "COVERAGE: To get digital services right, government needs to stay crisis-ready"
-date: April 15, 2021
+date: 2021-04-15
 source: StateScoop
 cta:
   text: Continue Reading

--- a/content/_news/2021-06-05-nj-tech-weekly.md
+++ b/content/_news/2021-06-05-nj-tech-weekly.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJTechWeekly.jpg
 title: "COVERAGE: Have a Future of Work Solution? There’s a New Jersey Accelerator for that!"
-date: June 5, 2021
+date: 2021-06-05
 source: NJ Tech Weekly
 cta:
   text: Continue Reading

--- a/content/_news/2021-06-23-roi-nj.md
+++ b/content/_news/2021-06-23-roi-nj.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/ROI-NJ.svg
 title: "COVERAGE: Game on: N.J., Stockton sign MOU to create Esports Innovation Center in Atlantic City"
-date: June 23, 2021
+date: 2021-06-23
 source: ROI-NJ
 cta:
   text: Continue Reading

--- a/content/_news/2021-07-13-jersey-best.md
+++ b/content/_news/2021-07-13-jersey-best.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/jersey-best-image.jpeg
 title: "COVERAGE: N.J. small businesses revamp and reinvent to keep doors open during crisis"
-date: July 13, 2021
+date: 2021-07-13
 source: JerseyBest.com
 cta:
   text: Continue Reading

--- a/content/_news/2021-07-27-fow-accelerator-launch.md
+++ b/content/_news/2021-07-27-fow-accelerator-launch.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/fow-news.jpg
 title: "POST: More Than Innovation, Sparking A Movement To Support Workers"
 promoted: 0
-date: July 27, 2021
+date: 2021-07-27
 source: Medium
 cta:
   text: Continue Reading

--- a/content/_news/2021-07-27-fow-accelerator-launch.md
+++ b/content/_news/2021-07-27-fow-accelerator-launch.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/fow-news.jpg
 title: "POST: More Than Innovation, Sparking A Movement To Support Workers"
-promoted:
+promoted: 0
 date: July 27, 2021
 source: Medium
 cta:

--- a/content/_news/2021-07-27-politico-eda.md
+++ b/content/_news/2021-07-27-politico-eda.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/politico.jpg
 title: "COVERAGE: New Jersey ranks 3rd in distributing grants to small business"
-promoted:
+promoted: 0
 date: July 27, 2021
 source: Politico
 cta:

--- a/content/_news/2021-07-27-politico-eda.md
+++ b/content/_news/2021-07-27-politico-eda.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/politico.jpg
 title: "COVERAGE: New Jersey ranks 3rd in distributing grants to small business"
 promoted: 0
-date: July 27, 2021
+date: 2021-07-27
 source: Politico
 cta:
   text: Continue Reading

--- a/content/_news/2021-09-02-fow-accelerator.md
+++ b/content/_news/2021-09-02-fow-accelerator.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/fowa-pic.jpg
 title: "POST: Innovating an Inclusive Open Innovation Challenge"
-promoted:
+promoted: 0
 date: September 2, 2021
 source: Medium
 cta:

--- a/content/_news/2021-09-02-fow-accelerator.md
+++ b/content/_news/2021-09-02-fow-accelerator.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/fowa-pic.jpg
 title: "POST: Innovating an Inclusive Open Innovation Challenge"
 promoted: 0
-date: September 2, 2021
+date: 2021-09-02
 source: Medium
 cta:
   text: Continue Reading

--- a/content/_news/2021-10-04-civic-tech.md
+++ b/content/_news/2021-10-04-civic-tech.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/civic-innovation-corps.png
 title: "POST: Finding a Path Through Civic Tech: Asking What Technology Can Do For Our World"
 promoted: 0
-date: October 4, 2021
+date: 2021-10-04
 source: Medium
 cta:
   text: Continue Reading

--- a/content/_news/2021-10-04-civic-tech.md
+++ b/content/_news/2021-10-04-civic-tech.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/civic-innovation-corps.png
 title: "POST: Finding a Path Through Civic Tech: Asking What Technology Can Do For Our World"
-promoted:
+promoted: 0
 date: October 4, 2021
 source: Medium
 cta:

--- a/content/_news/2021-12-13-FOWA-cohort.md
+++ b/content/_news/2021-12-13-FOWA-cohort.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/medium-logo.png
 title: "POST: Assembling the Future of Work Accelerator’s Inaugural Cohort"
-promoted: 
+promoted: 0
 date: December 13, 2021
 source: Medium
 cta:

--- a/content/_news/2021-12-13-FOWA-cohort.md
+++ b/content/_news/2021-12-13-FOWA-cohort.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/medium-logo.png
 title: "POST: Assembling the Future of Work Accelerator’s Inaugural Cohort"
 promoted: 0
-date: December 13, 2021
+date: 2021-12-13
 source: Medium
 cta:
   text: Continue Reading

--- a/content/_news/2021-12-14-R4A.md
+++ b/content/_news/2021-12-14-R4A.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/R4A-logo.png
 title: "PRESS RELEASE: New Jersey Recognized in New National Report as an Honor Roll State for Data-Driven and Evidence-Based Policymaking"
 promoted: 0
-date: December 14, 2021
+date: 2021-12-14
 source: Results For America
 cta:
   text: Continue Reading

--- a/content/_news/2021-12-14-R4A.md
+++ b/content/_news/2021-12-14-R4A.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/R4A-logo.png
 title: "PRESS RELEASE: New Jersey Recognized in New National Report as an Honor Roll State for Data-Driven and Evidence-Based Policymaking"
-promoted: 
+promoted: 0
 date: December 14, 2021
 source: Results For America
 cta:

--- a/content/_news/2021-12-14-UI-modernization.md
+++ b/content/_news/2021-12-14-UI-modernization.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/insidernj-logo.png
 title: "COVERAGE: New Jersey Selected as Pilot State for Federal Unemployment Improvement Project"
-promoted:
+promoted: 0
 date: December 14, 2021
 source: InsiderNJ
 cta:

--- a/content/_news/2021-12-14-UI-modernization.md
+++ b/content/_news/2021-12-14-UI-modernization.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/insidernj-logo.png
 title: "COVERAGE: New Jersey Selected as Pilot State for Federal Unemployment Improvement Project"
 promoted: 0
-date: December 14, 2021
+date: 2021-12-14
 source: InsiderNJ
 cta:
   text: Continue Reading

--- a/content/_news/2022-02-17-FOW-NJ-Spotlight.md
+++ b/content/_news/2022-02-17-FOW-NJ-Spotlight.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-spotlight.png
 title: "COVERAGE: Workers need help facing uncertain future, task force says"
-promoted: 
+promoted: 0
 date: February 17, 2022
 source: SpotlightNJ
 cta:

--- a/content/_news/2022-02-17-FOW-NJ-Spotlight.md
+++ b/content/_news/2022-02-17-FOW-NJ-Spotlight.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-spotlight.png
 title: "COVERAGE: Workers need help facing uncertain future, task force says"
 promoted: 0
-date: February 17, 2022
+date: 2022-02-17
 source: SpotlightNJ
 cta:
   text: Continue Reading

--- a/content/_news/2022-02-17-FOW-Task-Force-Report-Release.md
+++ b/content/_news/2022-02-17-FOW-Task-Force-Report-Release.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/FOW-report-pic.png
 title: "RELEASE: Governor Murphy Announces the New Jersey State Future of Work Task Force’s Roadmap and Recommendations"
-promoted: 
+promoted: 0
 date: February 17, 2022
 source: NJGov
 cta:

--- a/content/_news/2022-02-17-FOW-Task-Force-Report-Release.md
+++ b/content/_news/2022-02-17-FOW-Task-Force-Report-Release.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/FOW-report-pic.png
 title: "RELEASE: Governor Murphy Announces the New Jersey State Future of Work Task Force’s Roadmap and Recommendations"
 promoted: 0
-date: February 17, 2022
+date: 2022-02-17
 source: NJGov
 cta:
   text: Continue Reading

--- a/content/_news/2022-03-16-Office-of-Innovation-nomination.md
+++ b/content/_news/2022-03-16-Office-of-Innovation-nomination.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/state-scoop-awards.png
 title: "RECOGNITION: New Jersey's COVID-19 Information Hub nominated by StateScoop for State IT Innovation of the Year"
 promoted: 0
-date: March 14, 2022
+date: 2022-03-14
 source: StateScoop
 cta:
   text: Continue Reading

--- a/content/_news/2022-03-16-Office-of-Innovation-nomination.md
+++ b/content/_news/2022-03-16-Office-of-Innovation-nomination.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/state-scoop-awards.png
 title: "RECOGNITION: New Jersey's COVID-19 Information Hub nominated by StateScoop for State IT Innovation of the Year"
-promoted: 
+promoted: 0
 date: March 14, 2022
 source: StateScoop
 cta:

--- a/content/_news/2022-03-18-NJ-launches-widget-help-cannabiz.md
+++ b/content/_news/2022-03-18-NJ-launches-widget-help-cannabiz.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/nj-biz.png
 title: "COVERAGE: NJ launches widget to help cannabiz hopefuls navigate setting up a business"
 promoted: 0
-date: March 18, 2022
+date: 2022-03-18
 source: NJBIZ
 cta:
   text: Continue Reading

--- a/content/_news/2022-03-18-NJ-launches-widget-help-cannabiz.md
+++ b/content/_news/2022-03-18-NJ-launches-widget-help-cannabiz.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/nj-biz.png
 title: "COVERAGE: NJ launches widget to help cannabiz hopefuls navigate setting up a business"
-promoted: 
+promoted: 0
 date: March 18, 2022
 source: NJBIZ
 cta:

--- a/content/_news/2022-04-29-NJDOL-updates-unemployment-app.md
+++ b/content/_news/2022-04-29-NJDOL-updates-unemployment-app.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/nj-biz.png
 title: "COVERAGE: NJDOL updates unemployment app, with further improvements expected"
-promoted: 
+promoted: 0
 date: April 29, 2022
 source: NJBIZ
 cta:

--- a/content/_news/2022-04-29-NJDOL-updates-unemployment-app.md
+++ b/content/_news/2022-04-29-NJDOL-updates-unemployment-app.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/nj-biz.png
 title: "COVERAGE: NJDOL updates unemployment app, with further improvements expected"
 promoted: 0
-date: April 29, 2022
+date: 2022-04-29
 source: NJBIZ
 cta:
   text: Continue Reading

--- a/content/_news/2022-05-22-UI-emails.md
+++ b/content/_news/2022-05-22-UI-emails.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/ui-template.png
 title: "REPORT: New Jersey Unemployment Insurance Emails: Redesign, Beta Results, and Analysis"
 promoted: 0
-date: May 22, 2022
+date: 2022-05-22
 source:
 cta:
   text: Continue Reading

--- a/content/_news/2022-05-22-UI-emails.md
+++ b/content/_news/2022-05-22-UI-emails.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/ui-template.png
 title: "REPORT: New Jersey Unemployment Insurance Emails: Redesign, Beta Results, and Analysis"
-promoted: 
+promoted: 0
 date: May 22, 2022
 source:
 cta:

--- a/content/_news/2022-06-22-NJ-data-driven-content.md
+++ b/content/_news/2022-06-22-NJ-data-driven-content.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/statescoop.png
 title: "CASE STUDY: Inside New Jersey’s data-driven content strategy to boost service delivery"
 promoted: 0
-date: June 22, 2022
+date: 2022-06-22
 source: StateScoop
 cta:
   text: Continue Reading

--- a/content/_news/2022-06-22-NJ-data-driven-content.md
+++ b/content/_news/2022-06-22-NJ-data-driven-content.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/statescoop.png
 title: "CASE STUDY: Inside New Jersey’s data-driven content strategy to boost service delivery"
-promoted: 
+promoted: 0
 date: June 22, 2022
 source: StateScoop
 cta:

--- a/content/_news/2022-06-30-budget.md
+++ b/content/_news/2022-06-30-budget.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/murphy-sign.jpg
 title: "PRESS RELEASE: Governor Murphy Signs Fiscal Year 2023 Appropriations Act into Law"
-promoted: 
+promoted: 0
 date: June 30, 2022
 source: Office of the Governor
 cta:

--- a/content/_news/2022-06-30-budget.md
+++ b/content/_news/2022-06-30-budget.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/murphy-sign.jpg
 title: "PRESS RELEASE: Governor Murphy Signs Fiscal Year 2023 Appropriations Act into Law"
 promoted: 0
-date: June 30, 2022
+date: 2022-06-30
 source: Office of the Governor
 cta:
   text: Continue Reading

--- a/content/_news/2022-07-07-timeline-release.md
+++ b/content/_news/2022-07-07-timeline-release.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/njdol.jpg
 title: "PRESS RELEASE: NJDOL Commissioner Announces New Maternity Coverage Tool to Guide Expecting Parents on Available Leave Benefits"
-promoted: 
+promoted: 0
 date: July 7, 2022
 source: Office of the Governor
 cta:

--- a/content/_news/2022-07-07-timeline-release.md
+++ b/content/_news/2022-07-07-timeline-release.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/njdol.jpg
 title: "PRESS RELEASE: NJDOL Commissioner Announces New Maternity Coverage Tool to Guide Expecting Parents on Available Leave Benefits"
 promoted: 0
-date: July 7, 2022
+date: 2022-07-07
 source: Office of the Governor
 cta:
   text: Continue Reading

--- a/content/_news/2022-11-14-public-engagement-survey.md
+++ b/content/_news/2022-11-14-public-engagement-survey.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/survey-pic.png
 title: "POST: How we used a simple survey tool to elevate public engagement"
-promoted: 
+promoted: 0
 date: November 14, 2022
 source: Medium
 cta:

--- a/content/_news/2022-11-14-public-engagement-survey.md
+++ b/content/_news/2022-11-14-public-engagement-survey.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/survey-pic.png
 title: "POST: How we used a simple survey tool to elevate public engagement"
 promoted: 0
-date: November 14, 2022
+date: 2022-11-14
 source: Medium
 cta:
   text: Continue Reading

--- a/content/_news/2023-02-06-LiLA-grant.md
+++ b/content/_news/2023-02-06-LiLA-grant.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "GRANT OPPORTUNITY: Lifelong Learning Accounts (LiLA)"
-promoted: 
+promoted: 0
 date: February 6, 2023
 source: NJDOL
 cta:

--- a/content/_news/2023-02-06-LiLA-grant.md
+++ b/content/_news/2023-02-06-LiLA-grant.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "GRANT OPPORTUNITY: Lifelong Learning Accounts (LiLA)"
 promoted: 0
-date: February 6, 2023
+date: 2023-02-06
 source: NJDOL
 cta:
   text: Continue Reading

--- a/content/_news/2023-02-08-ARRIVE-program.md
+++ b/content/_news/2023-02-08-ARRIVE-program.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy Proposes $10M Investment to Expand ARRIVE Together Law Enforcement-Mental Health Collaboration Statewide"
-promoted: 
+promoted: 0
 date: February 8, 2023
 source: NJGOV
 cta:

--- a/content/_news/2023-02-08-ARRIVE-program.md
+++ b/content/_news/2023-02-08-ARRIVE-program.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy Proposes $10M Investment to Expand ARRIVE Together Law Enforcement-Mental Health Collaboration Statewide"
 promoted: 0
-date: February 8, 2023
+date: 2023-02-08
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2023-02-08-LiLA-program.md
+++ b/content/_news/2023-02-08-LiLA-program.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/ROI-NJ.svg
 title: "COVERAGE: NJDOL to fund 2-year, $10M pilot program to provide job coaching, training and support"
 promoted: 0
-date: February 8, 2023
+date: 2023-02-08
 source: ROI-NJ
 cta:
   text: Continue Reading

--- a/content/_news/2023-02-08-LiLA-program.md
+++ b/content/_news/2023-02-08-LiLA-program.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/ROI-NJ.svg
 title: "COVERAGE: NJDOL to fund 2-year, $10M pilot program to provide job coaching, training and support"
-promoted: 
+promoted: 0
 date: February 8, 2023
 source: ROI-NJ
 cta:

--- a/content/_news/2023-03-09-RGGI-Public-Engagement.md
+++ b/content/_news/2023-03-09-RGGI-Public-Engagement.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/rggi-bg.png
 title: "POST: How New Jersey Tapped the Public to Help Shape its Climate Future"
 promoted: 0
-date: March 9, 2023
+date: 2023-03-09
 source: Medium.com
 cta:
   text: Continue Reading

--- a/content/_news/2023-03-09-RGGI-Public-Engagement.md
+++ b/content/_news/2023-03-09-RGGI-Public-Engagement.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/rggi-bg.png
 title: "POST: How New Jersey Tapped the Public to Help Shape its Climate Future"
-promoted: 
+promoted: 0
 date: March 9, 2023
 source: Medium.com
 cta:

--- a/content/_news/2023-03-31-transgender-nj-gov.md
+++ b/content/_news/2023-03-31-transgender-nj-gov.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/transgender-web.jpg
 title: "RELEASE: On International Transgender Day of Visibility, Governor Murphy Announces the Launch of New Transgender Information Hub"
 promoted: 0
-date: March 31, 2023
+date: 2023-03-31
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2023-03-31-transgender-nj-gov.md
+++ b/content/_news/2023-03-31-transgender-nj-gov.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/transgender-web.jpg
 title: "RELEASE: On International Transgender Day of Visibility, Governor Murphy Announces the Launch of New Transgender Information Hub"
-promoted: 
+promoted: 0
 date: March 31, 2023
 source: NJGOV
 cta:

--- a/content/_news/2023-04-02-transgender-website.md
+++ b/content/_news/2023-04-02-transgender-website.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/transgender-nj-gov.png
 title: "COVERAGE: New Jersey Launches Information Hub for Trans Individuals"
-promoted: 
+promoted: 0
 date: April 4, 2023
 source: Government Technology
 cta:

--- a/content/_news/2023-04-02-transgender-website.md
+++ b/content/_news/2023-04-02-transgender-website.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/transgender-nj-gov.png
 title: "COVERAGE: New Jersey Launches Information Hub for Trans Individuals"
 promoted: 0
-date: April 4, 2023
+date: 2023-04-04
 source: Government Technology
 cta:
   text: Continue Reading

--- a/content/_news/2023-06-13-better-government-tech.md
+++ b/content/_news/2023-06-13-better-government-tech.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/wapo-logo.png
 title: "OP-ED: Better government tech starts with people. New Jersey shows how."
-promoted: 
+promoted: 0
 date: June 13, 2023
 source: Washington Post
 cta:

--- a/content/_news/2023-06-13-better-government-tech.md
+++ b/content/_news/2023-06-13-better-government-tech.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/wapo-logo.png
 title: "OP-ED: Better government tech starts with people. New Jersey shows how."
 promoted: 0
-date: June 13, 2023
+date: 2023-06-13
 source: Washington Post
 cta:
   text: Continue Reading

--- a/content/_news/2023-09-07-UI-heldrich-report.md
+++ b/content/_news/2023-09-07-UI-heldrich-report.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/heldrich.png
 title: "REPORT: New Jersey’s Worker-centered Approach to Improving the Administration of Unemployment Insurance"
 promoted: 0
-date: September 7, 2023
+date: 2023-09-07
 source: Heldrich Center for Workforce Development
 cta:
   text: Continue Reading

--- a/content/_news/2023-09-07-UI-heldrich-report.md
+++ b/content/_news/2023-09-07-UI-heldrich-report.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/heldrich.png
 title: "REPORT: New Jersey’s Worker-centered Approach to Improving the Administration of Unemployment Insurance"
-promoted: 
+promoted: 0
 date: September 7, 2023
 source: Heldrich Center for Workforce Development
 cta:

--- a/content/_news/2023-1-6-NJDOL-worker-protections.md
+++ b/content/_news/2023-1-6-NJDOL-worker-protections.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/njdol.jpg
 title: "RELEASE: NJDOL Reflects on a Year of Enhanced Worker Protections, Improved Unemployment Application as Garden State Touts More Workers, Employers Than Ever Before"
 promoted: 0
-date: January 6, 2023
+date: 2023-01-06
 source: NJDOL
 cta:
   text: Continue Reading

--- a/content/_news/2023-1-6-NJDOL-worker-protections.md
+++ b/content/_news/2023-1-6-NJDOL-worker-protections.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/njdol.jpg
 title: "RELEASE: NJDOL Reflects on a Year of Enhanced Worker Protections, Improved Unemployment Application as Garden State Touts More Workers, Employers Than Ever Before"
-promoted: 
+promoted: 0
 date: January 6, 2023
 source: NJDOL
 cta:

--- a/content/_news/2023-10-10-NJ-AI-task-force.md
+++ b/content/_news/2023-10-10-NJ-AI-task-force.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy Establishes State Artificial Intelligence Task Force"
-promoted: 
+promoted: 0
 date: October 10, 2023
 source: NJGOV
 cta:

--- a/content/_news/2023-10-10-NJ-AI-task-force.md
+++ b/content/_news/2023-10-10-NJ-AI-task-force.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy Establishes State Artificial Intelligence Task Force"
 promoted: 0
-date: October 10, 2023
+date: 2023-10-10
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2023-10-12-NJDOL-federal-grant.md
+++ b/content/_news/2023-10-12-NJDOL-federal-grant.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/njdol.jpg
 title: "RELEASE: NJ Receives $11M+ Federal Grant to Continue Unemployment System Improvements"
-promoted: 
+promoted: 0
 date: October 12, 2023
 source: Department of Labor & Workforce Development
 cta:

--- a/content/_news/2023-10-12-NJDOL-federal-grant.md
+++ b/content/_news/2023-10-12-NJDOL-federal-grant.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/njdol.jpg
 title: "RELEASE: NJ Receives $11M+ Federal Grant to Continue Unemployment System Improvements"
 promoted: 0
-date: October 12, 2023
+date: 2023-10-12
 source: Department of Labor & Workforce Development
 cta:
   text: Continue Reading

--- a/content/_news/2023-11-17-NJ-AI-policy.md
+++ b/content/_news/2023-11-17-NJ-AI-policy.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy Announces New Policy to Promote State Employees’ Responsible Use of Generative Artificial Intelligence"
 promoted: 0
-date: November 17, 2023
+date: 2023-11-17
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2023-11-17-NJ-AI-policy.md
+++ b/content/_news/2023-11-17-NJ-AI-policy.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy Announces New Policy to Promote State Employees’ Responsible Use of Generative Artificial Intelligence"
-promoted: 
+promoted: 0
 date: November 17, 2023
 source: NJGOV
 cta:

--- a/content/_news/2023-11-17-basic-needs-resource-launch.md
+++ b/content/_news/2023-11-17-basic-needs-resource-launch.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Office of the Secretary of Higher Education Launches BasicNeeds.NJ.gov Resource Hub at Convening of Campus Practitioners"
-promoted: 
+promoted: 0
 date: November 17, 2023
 source: NJGOV
 cta:

--- a/content/_news/2023-11-17-basic-needs-resource-launch.md
+++ b/content/_news/2023-11-17-basic-needs-resource-launch.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Office of the Secretary of Higher Education Launches BasicNeeds.NJ.gov Resource Hub at Convening of Campus Practitioners"
 promoted: 0
-date: November 17, 2023
+date: 2023-11-17
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2023-11-20-NJ-AI-policy-GT.md
+++ b/content/_news/2023-11-20-NJ-AI-policy-GT.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/govtech.png
 title: "COVERAGE: New Jersey Unveils AI Policy to Guide Use by State Employees"
 promoted: 0
-date: November 20, 2023
+date: 2023-11-20
 source: Government Technology
 cta:
   text: Continue Reading

--- a/content/_news/2023-11-20-NJ-AI-policy-GT.md
+++ b/content/_news/2023-11-20-NJ-AI-policy-GT.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/govtech.png
 title: "COVERAGE: New Jersey Unveils AI Policy to Guide Use by State Employees"
-promoted: 
+promoted: 0
 date: November 20, 2023
 source: Government Technology
 cta:

--- a/content/_news/2023-11-20-basic-needs-tool-launch.md
+++ b/content/_news/2023-11-20-basic-needs-tool-launch.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/nj-biz.png
 title: "COVERAGE: NJ launches tool to help college students make ends meet "
 promoted: 0
-date: November 20, 2023
+date: 2023-11-20
 source: NJBIZ
 cta:
   text: Continue Reading

--- a/content/_news/2023-11-20-basic-needs-tool-launch.md
+++ b/content/_news/2023-11-20-basic-needs-tool-launch.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/nj-biz.png
 title: "COVERAGE: NJ launches tool to help college students make ends meet "
-promoted: 
+promoted: 0
 date: November 20, 2023
 source: NJBIZ
 cta:

--- a/content/_news/2023-12-19-NJ-AI-center.md
+++ b/content/_news/2023-12-19-NJ-AI-center.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/njcomlogo.png
 title: "COVERAGE: A ‘revolutionary’ AI center is coming to a New Jersey university"
 promoted: 0
-date: December 19, 2023
+date: 2023-12-19
 source: NJ.com
 cta:
   text: Continue Reading

--- a/content/_news/2023-12-19-NJ-AI-center.md
+++ b/content/_news/2023-12-19-NJ-AI-center.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/njcomlogo.png
 title: "COVERAGE: A ‘revolutionary’ AI center is coming to a New Jersey university"
-promoted:
+promoted: 0
 date: December 19, 2023
 source: NJ.com
 cta:

--- a/content/_news/2024-01-09-NJ-state-of-the-state.md
+++ b/content/_news/2024-01-09-NJ-state-of-the-state.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy appoints Chief Innovation Officer Beth Noveck as Chief AI Strategist, announces new initiatives as part of State of the State Address"
 promoted: 0
-date: January 9, 2024
+date: 2024-01-09
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2024-01-09-NJ-state-of-the-state.md
+++ b/content/_news/2024-01-09-NJ-state-of-the-state.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy appoints Chief Innovation Officer Beth Noveck as Chief AI Strategist, announces new initiatives as part of State of the State Address"
-promoted:
+promoted: 0
 date: January 9, 2024
 source: NJGOV
 cta:

--- a/content/_news/2024-01-31-NJ-new-chief-innovation-officer.md
+++ b/content/_news/2024-01-31-NJ-new-chief-innovation-officer.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy Announces Dave Cole as New Jersey State Chief Innovation Officer"
 promoted: 0
-date: January 31, 2024
+date: 2024-01-31
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2024-01-31-NJ-new-chief-innovation-officer.md
+++ b/content/_news/2024-01-31-NJ-new-chief-innovation-officer.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy Announces Dave Cole as New Jersey State Chief Innovation Officer"
-promoted:
+promoted: 0
 date: January 31, 2024
 source: NJGOV
 cta:

--- a/content/_news/2024-02-01-dave-cole-nj-innovation-officer.md
+++ b/content/_news/2024-02-01-dave-cole-nj-innovation-officer.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/ROI-NJ.svg
 title: "COVERAGE: Dave Cole named chief innovation officer for state"
-promoted:
+promoted: 0
 date: February 1, 2024
 source: ROI NJ
 cta:

--- a/content/_news/2024-02-01-dave-cole-nj-innovation-officer.md
+++ b/content/_news/2024-02-01-dave-cole-nj-innovation-officer.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/ROI-NJ.svg
 title: "COVERAGE: Dave Cole named chief innovation officer for state"
 promoted: 0
-date: February 1, 2024
+date: 2024-02-01
 source: ROI NJ
 cta:
   text: Continue Reading

--- a/content/_news/2024-02-24-chief-ai-strategist-steve-adubato.md
+++ b/content/_news/2024-02-24-chief-ai-strategist-steve-adubato.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/pbs.svg
 title: "COVERAGE: Chief AI Strategist Interviewed on Think Tank with Steve Adubato"
 promoted: 0
-date: February 24, 2024
+date: 2024-02-24
 source: NJPBS
 cta:
   text: Watch the Interview

--- a/content/_news/2024-02-24-chief-ai-strategist-steve-adubato.md
+++ b/content/_news/2024-02-24-chief-ai-strategist-steve-adubato.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/pbs.svg
 title: "COVERAGE: Chief AI Strategist Interviewed on Think Tank with Steve Adubato"
-promoted: 
+promoted: 0
 date: February 24, 2024
 source: NJPBS
 cta:

--- a/content/_news/2024-03-01-generative-ai-innovation-dave-cole.md
+++ b/content/_news/2024-03-01-generative-ai-innovation-dave-cole.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/statescoop.png
 title: "COVERAGE: Chief Innovation Officer Dave Cole Discusses Priorities, Plans"
-promoted: 
+promoted: 0
 date: March 1, 2024
 source: STATESCOOP
 cta:

--- a/content/_news/2024-03-01-generative-ai-innovation-dave-cole.md
+++ b/content/_news/2024-03-01-generative-ai-innovation-dave-cole.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/statescoop.png
 title: "COVERAGE: Chief Innovation Officer Dave Cole Discusses Priorities, Plans"
 promoted: 0
-date: March 1, 2024
+date: 2024-03-01
 source: STATESCOOP
 cta:
   text: Listen to the Podcast

--- a/content/_news/2024-03-04-beth-bloomberg-intelligence.md
+++ b/content/_news/2024-03-04-beth-bloomberg-intelligence.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/BSN-bloomberg.jpeg
 title: "COVERAGE: Chief A.I. Strategist Interviewed on Bloomberg Intelligence Podcast"
 promoted: 0
-date: March 4, 2024
+date: 2024-03-04
 source: Bloomberg
 cta:
   text: Listen to the Podcast

--- a/content/_news/2024-03-04-beth-bloomberg-intelligence.md
+++ b/content/_news/2024-03-04-beth-bloomberg-intelligence.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/BSN-bloomberg.jpeg
 title: "COVERAGE: Chief A.I. Strategist Interviewed on Bloomberg Intelligence Podcast"
-promoted: 
+promoted: 0
 date: March 4, 2024
 source: Bloomberg
 cta:

--- a/content/_news/2024-03-08-govtech-ai.md
+++ b/content/_news/2024-03-08-govtech-ai.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/govtech.png
 title: "COVERAGE: Chief A.I. Strategist, State of NJ featured in Government Technology Article on Artificial Intelligence"
 promoted: 0
-date: March 8, 2024
+date: 2024-03-08
 source: Government Technology
 cta:
   text: Continue Reading

--- a/content/_news/2024-03-08-govtech-ai.md
+++ b/content/_news/2024-03-08-govtech-ai.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/govtech.png
 title: "COVERAGE: Chief A.I. Strategist, State of NJ featured in Government Technology Article on Artificial Intelligence"
-promoted: 
+promoted: 0
 date: March 8, 2024
 source: Government Technology
 cta:

--- a/content/_news/2024-03-08-govtech-nj-ai-leadership.md
+++ b/content/_news/2024-03-08-govtech-nj-ai-leadership.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/govtech.png
 title: "COVERAGE: Chief A.I. Strategist Quoted in Government Technology Article Highlighting NJ's National Leadership on AI"
-promoted: 
+promoted: 0
 date: March 8, 2024 
 source: Government Technology
 cta:

--- a/content/_news/2024-03-08-govtech-nj-ai-leadership.md
+++ b/content/_news/2024-03-08-govtech-nj-ai-leadership.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/govtech.png
 title: "COVERAGE: Chief A.I. Strategist Quoted in Government Technology Article Highlighting NJ's National Leadership on AI"
 promoted: 0
-date: March 8, 2024 
+date: 2024-03-08
 source: Government Technology
 cta:
   text: Continue Reading

--- a/content/_news/2024-03-15-my-career-nj-launch.md
+++ b/content/_news/2024-03-15-my-career-nj-launch.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy, Labor Commissioner Asaro-Angelo & Chief Innovation Officer Cole Announce Launch of My Career NJ"
 promoted: 0
-date: March 14, 2024 
+date: 2024-03-14
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2024-03-15-my-career-nj-launch.md
+++ b/content/_news/2024-03-15-my-career-nj-launch.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy, Labor Commissioner Asaro-Angelo & Chief Innovation Officer Cole Announce Launch of My Career NJ"
-promoted: 
+promoted: 0
 date: March 14, 2024 
 source: NJGOV
 cta:

--- a/content/_news/2024-04-11-fastcompany-nj-ai-job-search.md
+++ b/content/_news/2024-04-11-fastcompany-nj-ai-job-search.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/fastcompany-logo.png
 title: "Coverage: New Jersey Is Turning to AI to Improve The Job Search Process"
 promoted: 0
-date: April 11, 2024 
+date: 2024-04-11
 source: Fast Company
 cta:
   text: Continue Reading

--- a/content/_news/2024-04-11-fastcompany-nj-ai-job-search.md
+++ b/content/_news/2024-04-11-fastcompany-nj-ai-job-search.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/fastcompany-logo.png
 title: "Coverage: New Jersey Is Turning to AI to Improve The Job Search Process"
-promoted: 
+promoted: 0
 date: April 11, 2024 
 source: Fast Company
 cta:

--- a/content/_news/2024-05-05-apolitical-using-agile-development-business.md
+++ b/content/_news/2024-05-05-apolitical-using-agile-development-business.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/apolitical-logo.png
 title: "ARTICLE: How the Office of Innovation Used Agile Practices to Build Business.NJ.gov "
-promoted: 
+promoted: 0
 date: May 5, 2024 
 source: Apolitical
 cta:

--- a/content/_news/2024-05-05-apolitical-using-agile-development-business.md
+++ b/content/_news/2024-05-05-apolitical-using-agile-development-business.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/apolitical-logo.png
 title: "ARTICLE: How the Office of Innovation Used Agile Practices to Build Business.NJ.gov "
 promoted: 0
-date: May 5, 2024 
+date: 2024-05-05
 source: Apolitical
 cta:
   text: Continue Reading

--- a/content/_news/2024-05-21-fednews-ui-app-launch.md
+++ b/content/_news/2024-05-21-fednews-ui-app-launch.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/federal_news_network_logo.jpg
 title: "COVERAGE: Chief Innovation Officer Quoted In Article Highlighting NJ As Model For Modernizing Unemployment Insurance Systems"
-promoted: 
+promoted: 0
 date: May 21, 2024 
 source: Federal News Network
 cta:

--- a/content/_news/2024-05-21-fednews-ui-app-launch.md
+++ b/content/_news/2024-05-21-fednews-ui-app-launch.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/federal_news_network_logo.jpg
 title: "COVERAGE: Chief Innovation Officer Quoted In Article Highlighting NJ As Model For Modernizing Unemployment Insurance Systems"
 promoted: 0
-date: May 21, 2024 
+date: 2024-05-21
 source: Federal News Network
 cta:
   text: Continue Reading

--- a/content/_news/2024-05-21-njmonitor-ui-app-launch.md
+++ b/content/_news/2024-05-21-njmonitor-ui-app-launch.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/nj-monitor-logo.jpg
 title: "COVERAGE: State Unveils ‘New and Innovative’ Update to Unemployment System"
-promoted:
+promoted: 0
 date: May 21, 2024 
 source: NJ Monitor
 cta:

--- a/content/_news/2024-05-21-njmonitor-ui-app-launch.md
+++ b/content/_news/2024-05-21-njmonitor-ui-app-launch.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/nj-monitor-logo.jpg
 title: "COVERAGE: State Unveils ‘New and Innovative’ Update to Unemployment System"
 promoted: 0
-date: May 21, 2024 
+date: 2024-05-21
 source: NJ Monitor
 cta:
   text: Continue Reading

--- a/content/_news/2024-05-21-ui-application-launch.md
+++ b/content/_news/2024-05-21-ui-application-launch.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy and Acting U.S. Labor Secretary Su Highlight New, Easy-to-Use Online Unemployment Insurance Application"
 promoted: 0
-date: May 21, 2024 
+date: 2024-05-21
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2024-05-21-ui-application-launch.md
+++ b/content/_news/2024-05-21-ui-application-launch.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy and Acting U.S. Labor Secretary Su Highlight New, Easy-to-Use Online Unemployment Insurance Application"
-promoted: 
+promoted: 0
 date: May 21, 2024 
 source: NJGOV
 cta:

--- a/content/_news/2024-05-23-beth-kevin-werbach-podcast.md
+++ b/content/_news/2024-05-23-beth-kevin-werbach-podcast.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/kevin_werbach_podcast.webp
 title: "COVERAGE: Chief AI Strategist Discusses How AI Is Transforming Government Services"
-promoted: 
+promoted: 0
 date: May 23, 2024 
 source: Apple Podcasts
 cta:

--- a/content/_news/2024-05-23-beth-kevin-werbach-podcast.md
+++ b/content/_news/2024-05-23-beth-kevin-werbach-podcast.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/kevin_werbach_podcast.webp
 title: "COVERAGE: Chief AI Strategist Discusses How AI Is Transforming Government Services"
 promoted: 0
-date: May 23, 2024 
+date: 2024-05-23
 source: Apple Podcasts
 cta:
   text: Listen to the Podcast

--- a/content/_news/2024-06-04-govtech-ai-survey.md
+++ b/content/_news/2024-06-04-govtech-ai-survey.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/govtech.png
 title: "ARTICLE: New Jersey Co-Creates AI Strategy With Public-Sector Staff"
-promoted: 
+promoted: 0
 date: June 4, 2024 
 source: Government Technology
 cta:

--- a/content/_news/2024-06-04-govtech-ai-survey.md
+++ b/content/_news/2024-06-04-govtech-ai-survey.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/govtech.png
 title: "ARTICLE: New Jersey Co-Creates AI Strategy With Public-Sector Staff"
 promoted: 0
-date: June 4, 2024 
+date: 2024-06-04
 source: Government Technology
 cta:
   text: Continue Reading

--- a/content/_news/2024-06-05-drum-award.md
+++ b/content/_news/2024-06-05-drum-award.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/drum-awards.png
 title: "AWARD: Office of Innovation's C+E Lab Wins Gold At Drum Awards"
 promoted:  
-date: June 5, 2024
+date: 2024-06-05
 source: Marketing Americas
 cta:
   text: Continue Reading

--- a/content/_news/2024-07-03-ai-assistant-launch-release.md
+++ b/content/_news/2024-07-03-ai-assistant-launch-release.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy Unveils AI Tool For State Employees and Training Course For Responsible Use"
-promoted:
+promoted: 0
 date: July 3, 2024
 source: NJGOV
 cta:

--- a/content/_news/2024-07-03-ai-assistant-launch-release.md
+++ b/content/_news/2024-07-03-ai-assistant-launch-release.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy Unveils AI Tool For State Employees and Training Course For Responsible Use"
 promoted: 0
-date: July 3, 2024
+date: 2024-07-03
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2024-07-03-nj-biz-ai-assistant.md
+++ b/content/_news/2024-07-03-nj-biz-ai-assistant.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/nj-biz.png
 title: "Coverage: NJ Launches New AI Tool, Training for State Employees"
-promoted:
+promoted: 0
 date: July 3, 2024
 source: NJ Biz
 cta:

--- a/content/_news/2024-07-03-nj-biz-ai-assistant.md
+++ b/content/_news/2024-07-03-nj-biz-ai-assistant.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/nj-biz.png
 title: "Coverage: NJ Launches New AI Tool, Training for State Employees"
 promoted: 0
-date: July 3, 2024
+date: 2024-07-03
 source: NJ Biz
 cta:
   text: Continue Reading

--- a/content/_news/2024-07-05-govtech-ai-assistant-launch.md
+++ b/content/_news/2024-07-05-govtech-ai-assistant-launch.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/govtech.png
 title: "Coverage: NJ Unveils AI Training, Tool for State Government Workers"
 promoted: 0
-date: July 5, 2024
+date: 2024-07-05
 source: Government Technology
 cta:
   text: Continue Reading

--- a/content/_news/2024-07-05-govtech-ai-assistant-launch.md
+++ b/content/_news/2024-07-05-govtech-ai-assistant-launch.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/govtech.png
 title: "Coverage: NJ Unveils AI Training, Tool for State Government Workers"
-promoted: 
+promoted: 0
 date: July 5, 2024
 source: Government Technology
 cta:

--- a/content/_news/2024-07-24-ai-worker-survey.md
+++ b/content/_news/2024-07-24-ai-worker-survey.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Murphy Administration Seeks NJ Worker Input on Generative AI"
 promoted: 0
-date: July 24, 2024
+date: 2024-07-24
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2024-07-24-ai-worker-survey.md
+++ b/content/_news/2024-07-24-ai-worker-survey.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Murphy Administration Seeks NJ Worker Input on Generative AI"
-promoted: 
+promoted: 0
 date: July 24, 2024
 source: NJGOV
 cta:

--- a/content/_news/2024-07-24-direct-file.md
+++ b/content/_news/2024-07-24-direct-file.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy and US Department of Treasury Announce New Jersey will Join IRS Direct File"
-promoted: 
+promoted: 0
 date: July 24, 2024
 source: NJGOV
 cta:

--- a/content/_news/2024-07-24-direct-file.md
+++ b/content/_news/2024-07-24-direct-file.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Governor Murphy and US Department of Treasury Announce New Jersey will Join IRS Direct File"
 promoted: 0
-date: July 24, 2024
+date: 2024-07-24
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2024-07-26-disability-hub-launch.md
+++ b/content/_news/2024-07-26-disability-hub-launch.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Office of Innovation and NJ Human Services Launch Disability Information Hub"
-promoted: 
+promoted: 0
 date: July 26, 2024
 source: NJGOV
 cta:

--- a/content/_news/2024-07-26-disability-hub-launch.md
+++ b/content/_news/2024-07-26-disability-hub-launch.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Office of Innovation and NJ Human Services Launch Disability Information Hub"
 promoted: 0
-date: July 26, 2024
+date: 2024-07-26
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2024-07-26-kyw-disability-hub.md
+++ b/content/_news/2024-07-26-kyw-disability-hub.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/kyw.png
 title: "COVERAGE: New Jersey Launches Online Hub for Disability Information, Resources"
 promoted:  
-date: July 26, 2024
+date: 2024-07-26
 source: KYW
 cta:
   text: Listen To The Story

--- a/content/_news/2024-07-29-disability-hub-govtech.md
+++ b/content/_news/2024-07-29-disability-hub-govtech.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/govtech.png
 title: "COVERAGE: NJ Launches Online Information Hub for Disability Services"
 promoted: 0
-date: July 29, 2024
+date: 2024-07-29
 source: Government Technology
 cta:
   text: Continue Reading

--- a/content/_news/2024-07-29-disability-hub-govtech.md
+++ b/content/_news/2024-07-29-disability-hub-govtech.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/govtech.png
 title: "COVERAGE: NJ Launches Online Information Hub for Disability Services"
-promoted: 
+promoted: 0
 date: July 29, 2024
 source: Government Technology
 cta:

--- a/content/_news/2024-08-13-beeck-center-live-chat-study.md
+++ b/content/_news/2024-08-13-beeck-center-live-chat-study.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/beeckcenter.png
 title: "CASE STUDY: How a Live Chat Tool Streamlined Business Support Services in NJ"
-promoted: 
+promoted: 0
 date: August 13, 2024
 source: Beeck Center For Social Impact + Innovation
 cta:

--- a/content/_news/2024-08-13-beeck-center-live-chat-study.md
+++ b/content/_news/2024-08-13-beeck-center-live-chat-study.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/beeckcenter.png
 title: "CASE STUDY: How a Live Chat Tool Streamlined Business Support Services in NJ"
 promoted: 0
-date: August 13, 2024
+date: 2024-08-13
 source: Beeck Center For Social Impact + Innovation
 cta:
   text: Continue Reading

--- a/content/_news/2024-08-29-dave-statescoop-six-months.md
+++ b/content/_news/2024-08-29-dave-statescoop-six-months.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/statescoop.png
 title: "COVERAGE: Chief Innovation Officer Discusses OOI's Impact and Hiring Sprint"
 promoted: 0
-date: August 29, 2024
+date: 2024-08-29
 source: StateScoop
 cta:
   text: Continue Reading

--- a/content/_news/2024-08-29-dave-statescoop-six-months.md
+++ b/content/_news/2024-08-29-dave-statescoop-six-months.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/statescoop.png
 title: "COVERAGE: Chief Innovation Officer Discusses OOI's Impact and Hiring Sprint"
-promoted: 
+promoted: 0
 date: August 29, 2024
 source: StateScoop
 cta:

--- a/content/_news/2024-09-04-dave-statescoop-podcast.md
+++ b/content/_news/2024-09-04-dave-statescoop-podcast.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/statescoop-podcast.webp
 title: "LISTEN: Why New Jersey’s Innovation Office Is Expanding"
-promoted: 
+promoted: 0
 date: September 4, 2024
 source: StateScoop
 cta:

--- a/content/_news/2024-09-04-dave-statescoop-podcast.md
+++ b/content/_news/2024-09-04-dave-statescoop-podcast.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/statescoop-podcast.webp
 title: "LISTEN: Why New Jersey’s Innovation Office Is Expanding"
 promoted: 0
-date: September 4, 2024
+date: 2024-09-04
 source: StateScoop
 cta:
   text: Listen

--- a/content/_news/2024-09-12-beeck-center-ce-lab-study.md
+++ b/content/_news/2024-09-12-beeck-center-ce-lab-study.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/beeckcenter.png
 title: "CASE STUDY: Human-Centered Communication to Increase Service Uptake in New Jersey"
 promoted:  
-date: September 12, 2024
+date: 2024-09-12
 source: Beeck Center For Social Impact + Innovation
 cta:
   text: Continue Reading

--- a/content/_news/2024-09-18-govx-award.md
+++ b/content/_news/2024-09-18-govx-award.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/govx-award.jpg
 title: "AWARD: Office of Innovation Wins GovX Award from the Center for Digital Government"
 promoted: 0
-date: September 18, 2024
+date: 2024-09-18
 source: Center For Digital Government
 cta:
   text: Continue Reading

--- a/content/_news/2024-09-18-govx-award.md
+++ b/content/_news/2024-09-18-govx-award.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/govx-award.jpg
 title: "AWARD: Office of Innovation Wins GovX Award from the Center for Digital Government"
-promoted: 
+promoted: 0
 date: September 18, 2024
 source: Center For Digital Government
 cta:

--- a/content/_news/2024-09-27-impact-report-release.md
+++ b/content/_news/2024-09-27-impact-report-release.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Murphy Administration Releases Report Highlighting OOI’s Impact"
-promoted: 
+promoted: 0
 date: September 27, 2024
 source: NJGov
 cta:

--- a/content/_news/2024-09-27-impact-report-release.md
+++ b/content/_news/2024-09-27-impact-report-release.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Murphy Administration Releases Report Highlighting OOI’s Impact"
 promoted: 0
-date: September 27, 2024
+date: 2024-09-27
 source: NJGov
 cta:
   text: Continue Reading

--- a/content/_news/2024-10-01-collegeforyou-release.md
+++ b/content/_news/2024-10-01-collegeforyou-release.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: NJ Launches Campaign Empowering Residents to Pursue Affordable, Accessible Degrees in the State"
 promoted: 0
-date: October 1, 2024
+date: 2024-10-01
 source: NJGov
 cta:
   text: Continue Reading

--- a/content/_news/2024-10-01-collegeforyou-release.md
+++ b/content/_news/2024-10-01-collegeforyou-release.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: NJ Launches Campaign Empowering Residents to Pursue Affordable, Accessible Degrees in the State"
-promoted: 
+promoted: 0
 date: October 1, 2024
 source: NJGov
 cta:

--- a/content/_news/2024-11-12-ai-task-force-report-release.md
+++ b/content/_news/2024-11-12-ai-task-force-report-release.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Murphy Administration Releases Report from Artificial Intelligence Task Force, Furthers Leadership As The Innovation State"
-promoted:
+promoted: 0
 date: November 12, 2024
 source: NJGov
 cta:

--- a/content/_news/2024-11-12-ai-task-force-report-release.md
+++ b/content/_news/2024-11-12-ai-task-force-report-release.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Murphy Administration Releases Report from Artificial Intelligence Task Force, Furthers Leadership As The Innovation State"
 promoted: 0
-date: November 12, 2024
+date: 2024-11-12
 source: NJGov
 cta:
   text: Continue Reading

--- a/content/_news/2024-12-03-govtech-ai-task-force-report.md
+++ b/content/_news/2024-12-03-govtech-ai-task-force-report.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/govtech.png
 title: "COVERAGE: NJ AI Task Force Report Addresses Workforce, Innovation"
 promoted: 0
-date: December 3, 2024
+date: 2024-12-03
 source: Government Technology
 cta:
   text: Continue Reading

--- a/content/_news/2024-12-03-govtech-ai-task-force-report.md
+++ b/content/_news/2024-12-03-govtech-ai-task-force-report.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/govtech.png
 title: "COVERAGE: NJ AI Task Force Report Addresses Workforce, Innovation"
-promoted:
+promoted: 0
 date: December 3, 2024
 source: Government Technology
 cta:

--- a/content/_news/2024-12-04-beth-ai-training.md
+++ b/content/_news/2024-12-04-beth-ai-training.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/statescoop.png
 title: "ARTICLE: In New Jersey, Using AI Starts with Empowering Employees"
 promoted: 0
-date: December 4, 2024
+date: 2024-12-04
 source: StateScoop
 cta:
   text: Continue Reading

--- a/content/_news/2024-12-04-beth-ai-training.md
+++ b/content/_news/2024-12-04-beth-ai-training.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/statescoop.png
 title: "ARTICLE: In New Jersey, Using AI Starts with Empowering Employees"
-promoted:
+promoted: 0
 date: December 4, 2024
 source: StateScoop
 cta:

--- a/content/_news/2025-03-06-DirectFile.md
+++ b/content/_news/2025-03-06-DirectFile.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: New Jersey Launches Innovative IRS Direct File Program"
-promoted: 
+promoted: 0
 date: January 28, 2025
 source: NJGOV
 cta:

--- a/content/_news/2025-03-06-DirectFile.md
+++ b/content/_news/2025-03-06-DirectFile.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: New Jersey Launches Innovative IRS Direct File Program"
 promoted: 0
-date: January 28, 2025
+date: 2025-01-28
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2025-03-11-DirectFileUpdateArticle.md
+++ b/content/_news/2025-03-11-DirectFileUpdateArticle.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/njcomlogo.png
 title: "COVERAGE: 400K N.J. Retirees Can Now Use this Free Tax Return Service"
 promoted: 0
-date: March 11, 2025
+date: 2025-03-11
 source: NJ.COM
 cta:
   text: Continue Reading

--- a/content/_news/2025-03-11-DirectFileUpdateArticle.md
+++ b/content/_news/2025-03-11-DirectFileUpdateArticle.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/njcomlogo.png
 title: "COVERAGE: 400K N.J. Retirees Can Now Use this Free Tax Return Service"
-promoted: 
+promoted: 0
 date: March 11, 2025
 source: NJ.COM
 cta:

--- a/content/_news/2025-03-11-DirectFileUpdateRelease.md
+++ b/content/_news/2025-03-11-DirectFileUpdateRelease.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: New Jersey's Direct File Program Expands to Include Retirement Income Filers"
-promoted: 
+promoted: 0
 date: March 11, 2025
 source: NJGOV
 cta:

--- a/content/_news/2025-03-11-DirectFileUpdateRelease.md
+++ b/content/_news/2025-03-11-DirectFileUpdateRelease.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: New Jersey's Direct File Program Expands to Include Retirement Income Filers"
 promoted: 0
-date: March 11, 2025
+date: 2025-03-11
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2025-03-13-workertool.md
+++ b/content/_news/2025-03-13-workertool.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: NJ Dept of Labor Announces New Job Protection Checker to Guide Workers on Family and Medical Leave Laws"
 promoted: 0
-date: March 13, 2025
+date: 2025-03-13
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2025-03-13-workertool.md
+++ b/content/_news/2025-03-13-workertool.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: NJ Dept of Labor Announces New Job Protection Checker to Guide Workers on Family and Medical Leave Laws"
-promoted:
+promoted: 0
 date: March 13, 2025
 source: NJGOV
 cta:

--- a/content/_news/2025-04-02-FilingTaxes.md
+++ b/content/_news/2025-04-02-FilingTaxes.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/njcomlogo.png
 title: "COVERAGE: The tax filing deadline is coming. Here's how you can file your return for free."
 promoted: 0
-date: April 2, 2025
+date: 2025-04-02
 source: NJ.COM
 cta:
   text: Continue Reading

--- a/content/_news/2025-04-02-FilingTaxes.md
+++ b/content/_news/2025-04-02-FilingTaxes.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/njcomlogo.png
 title: "COVERAGE: The tax filing deadline is coming. Here's how you can file your return for free."
-promoted: 
+promoted: 0
 date: April 2, 2025
 source: NJ.COM
 cta:

--- a/content/_news/2025-05-01-aisandboxclip.md
+++ b/content/_news/2025-05-01-aisandboxclip.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/govtech.png
 title: "COVERAGE: New Jersey leads with AI Assistant for state workers"
-promoted: 
+promoted: 0
 date: May 1, 2025
 source: GOVTECH
 cta:

--- a/content/_news/2025-05-01-aisandboxclip.md
+++ b/content/_news/2025-05-01-aisandboxclip.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/govtech.png
 title: "COVERAGE: New Jersey leads with AI Assistant for state workers"
 promoted: 0
-date: May 1, 2025
+date: 2025-05-01
 source: GOVTECH
 cta:
   text: Continue Reading

--- a/content/_news/2025-05-05-rowanclip.md
+++ b/content/_news/2025-05-05-rowanclip.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/RowanLogo2.jpg
 title: "COVERAGE: CIO Keynotes AI Conference at Rowan University"
 promoted: 0
-date: May 5, 2025
+date: 2025-05-05
 source: ROWAN TODAY
 cta:
   text: Continue Reading

--- a/content/_news/2025-05-05-rowanclip.md
+++ b/content/_news/2025-05-05-rowanclip.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/RowanLogo2.jpg
 title: "COVERAGE: CIO Keynotes AI Conference at Rowan University"
-promoted: 
+promoted: 0
 date: May 5, 2025
 source: ROWAN TODAY
 cta:

--- a/content/_news/2025-05-06-BusinessNJGovImpact.md
+++ b/content/_news/2025-05-06-BusinessNJGovImpact.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Business.NJ.gov Celebrates 5 Years of Helping Thousands of Businesses"
 promoted: 0
-date: May 6, 2025
+date: 2025-05-06
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2025-05-06-BusinessNJGovImpact.md
+++ b/content/_news/2025-05-06-BusinessNJGovImpact.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: Business.NJ.gov Celebrates 5 Years of Helping Thousands of Businesses"
-promoted: 
+promoted: 0
 date: May 6, 2025
 source: NJGOV
 cta:

--- a/content/_news/2025-05-07-NJBIZ-clip.md
+++ b/content/_news/2025-05-07-NJBIZ-clip.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/nj-biz.png
 title: "COVERAGE: NJ Business Portal Saves Time for New Entrepreneurs"
 promoted: 0
-date: May 7, 2025
+date: 2025-05-07
 source: NJBIZ
 cta:
   text: Continue Reading

--- a/content/_news/2025-05-07-NJBIZ-clip.md
+++ b/content/_news/2025-05-07-NJBIZ-clip.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/nj-biz.png
 title: "COVERAGE: NJ Business Portal Saves Time for New Entrepreneurs"
-promoted: 
+promoted: 0
 date: May 7, 2025
 source: NJBIZ
 cta:

--- a/content/_news/2025-05-15-binjeclip.md
+++ b/content/_news/2025-05-15-binjeclip.md
@@ -2,7 +2,7 @@
 image: /assets/images/BINJE.png
 title: "COVERAGE: State touts success of Business.NJ.gov"
 promoted: 0
-date: May 15, 2025
+date: 2025-05-15
 source: BINJE
 cta:
   text: Continue Reading

--- a/content/_news/2025-05-15-binjeclip.md
+++ b/content/_news/2025-05-15-binjeclip.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/BINJE.png
 title: "COVERAGE: State touts success of Business.NJ.gov"
-promoted: 
+promoted: 0
 date: May 15, 2025
 source: BINJE
 cta:

--- a/content/_news/2025-05-30-FNNdirectfile.md
+++ b/content/_news/2025-05-30-FNNdirectfile.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/federal_news_network_logo.jpg
 title: "COVERAGE: IRS Direct File Sees Higher Scores Among Users"
-promoted: 
+promoted: 0
 date: May 30, 2025
 source: FEDERAL NEWS NETWORK
 cta:

--- a/content/_news/2025-05-30-FNNdirectfile.md
+++ b/content/_news/2025-05-30-FNNdirectfile.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/federal_news_network_logo.jpg
 title: "COVERAGE: IRS Direct File Sees Higher Scores Among Users"
 promoted: 0
-date: May 30, 2025
+date: 2025-05-30
 source: FEDERAL NEWS NETWORK
 cta:
   text: Continue Reading

--- a/content/_news/2025-06-05-rte50clip.md
+++ b/content/_news/2025-06-05-rte50clip.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/Route-Fifty-Today.webp
 title: "COVERAGE: Trust is the currency in local government"
-promoted: 
+promoted: 0
 date: June 4, 2025
 source: Route 50
 cta:

--- a/content/_news/2025-06-05-rte50clip.md
+++ b/content/_news/2025-06-05-rte50clip.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/Route-Fifty-Today.webp
 title: "COVERAGE: Trust is the currency in local government"
 promoted: 0
-date: June 4, 2025
+date: 2025-06-04
 source: Route 50
 cta:
   text: Continue Reading

--- a/content/_news/2025-06-12-statescoop-podcast.md
+++ b/content/_news/2025-06-12-statescoop-podcast.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/statescoop-podcast.webp
 title: "COVERAGE: Inside New Jersey’s Call Center Modernizations"
 promoted: 0
-date: June 12, 2025
+date: 2025-06-12
 source: STATESCOOP
 cta:
   text: Listen

--- a/content/_news/2025-06-12-statescoop-podcast.md
+++ b/content/_news/2025-06-12-statescoop-podcast.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/statescoop-podcast.webp
 title: "COVERAGE: Inside New Jersey’s Call Center Modernizations"
-promoted: 
+promoted: 0
 date: June 12, 2025
 source: STATESCOOP
 cta:

--- a/content/_news/2025-06-23-summer-ebt-release.md
+++ b/content/_news/2025-06-23-summer-ebt-release.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: New Jersey Distributes Summer EBT Benefits to More Than 693,000 Eligible Children"
 promoted: 0
-date: June 23, 2025
+date: 2025-06-23
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2025-06-23-summer-ebt-release.md
+++ b/content/_news/2025-06-23-summer-ebt-release.md
@@ -1,11 +1,12 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: New Jersey Distributes Summer EBT Benefits to More Than 693,000 Eligible Children"
-promoted: 4
+promoted: 0
 date: June 23, 2025
 source: NJGOV
 cta:
   text: Continue Reading
   link: "https://www.nj.gov/agriculture/news/press/2025/press250623a.html"
 ---
-The Office of Innovation used data science and AI to expand enrollment in Summer EBT to thousands more New Jersey kids, helping ensure they get nutritious food when school isn't in session. 
+
+The Office of Innovation used data science and AI to expand enrollment in Summer EBT to thousands more New Jersey kids, helping ensure they get nutritious food when school isn't in session.

--- a/content/_news/2025-07-09-codeforamericarank.md
+++ b/content/_news/2025-07-09-codeforamericarank.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/govtech.png
 title: "COVERAGE: New Jersey One of Three Top-Ranked States in AI Readiness Assessment"
 promoted: 0
-date: July 9, 2025
+date: 2025-07-09
 source: GOVTECH
 cta:
   text: Continue Reading

--- a/content/_news/2025-07-09-codeforamericarank.md
+++ b/content/_news/2025-07-09-codeforamericarank.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/govtech.png
 title: "COVERAGE: New Jersey One of Three Top-Ranked States in AI Readiness Assessment"
-promoted:
+promoted: 0
 date: July 9, 2025
 source: GOVTECH
 cta:

--- a/content/_news/2025-07-15-cfaranking-aiassistant.md
+++ b/content/_news/2025-07-15-cfaranking-aiassistant.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: New Jersey Named National Leader in AI Innovation in New Report"
 promoted: 0
-date: July 15, 2025
+date: 2025-07-15
 source: NJGOV
 cta:
   text: Continue Reading

--- a/content/_news/2025-07-15-cfaranking-aiassistant.md
+++ b/content/_news/2025-07-15-cfaranking-aiassistant.md
@@ -1,7 +1,7 @@
 ---
 image: /assets/images/news/NJ-seal.png
 title: "RELEASE: New Jersey Named National Leader in AI Innovation in New Report"
-promoted: 
+promoted: 0
 date: July 15, 2025
 source: NJGOV
 cta:

--- a/content/_news/2025-07-22-nyt-AI-assistant.md
+++ b/content/_news/2025-07-22-nyt-AI-assistant.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/New-York-Times-emblem.jpg
 title: "COVERAGE: The Cities and States That Are Getting It Right"
 promoted: 3
-date: July 22, 2025
+date: 2025-07-22
 source: The New York Times
 cta:
   text: Continue Reading

--- a/content/_news/2025-07-23-SummerEBTclip.md
+++ b/content/_news/2025-07-23-SummerEBTclip.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/njcomlogo.png
 title: "COVERAGE: How NJ Is Using AI to Ensure Kids Don’t Go Hungry This Summer"
 promoted: 2
-date: July 23, 2025
+date: 2025-07-23
 source: NJ.COM
 cta:
   text: Continue Reading

--- a/content/_news/2025-07-28-driverslicenses.md
+++ b/content/_news/2025-07-28-driverslicenses.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/whyylogo.png
 title: "COVERAGE: N.J. to put driver licenses on smartphones and mobile devices"
 promoted: 
-date: July 25, 2025
+date: 2025-07-25
 source: NPR WHYY
 cta:
   text: Continue Reading

--- a/content/_news/2025-08-19-Rte50AIclip.md
+++ b/content/_news/2025-08-19-Rte50AIclip.md
@@ -2,7 +2,7 @@
 image: /assets/images/news/Route-Fifty-Today.webp
 title: "COVERAGE: How New Jersey’s AI Assistant Saves the State Time and Money"
 promoted: 1
-date: August 19, 2025
+date: 2025-08-19
 source: ROUTE 50
 cta:
   text: Continue Reading


### PR DESCRIPTION
- [feat(decap): Add support for news posts](https://github.com/newjersey/innovation.nj.gov/pull/315/commits/c9f65e4ad44e522a93403d7b2fc488a42572d024)
  - all of the news post edits are simply to add a default 0 value to the `promoted` field
- [fix(decap): Allow creation of blog posts via decap](https://github.com/newjersey/innovation.nj.gov/pull/315/commits/ac51f6feea35cc99bfdf6e7093a689ec7b14e018)
  - the decap config was missing the `create: true` field for the blog collection